### PR TITLE
캘린더 높이 설정 계산 수정

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -93,7 +93,7 @@ const Calendar = () => {
             if (v?.childElementCount === 0) return;
             if (v) {
                 const indexInWeek = i % 7;
-                const testCount: number[] = [];
+                const isCount: number[] = [];
                 const totalLength: number[] = [];
                 for (let j = 1; j <= indexInWeek; j++) {
                     const preNode = boxRef.current[i - j];
@@ -104,23 +104,27 @@ const Calendar = () => {
                         const childWidth = Number(getComputedStyle(node).width.split("px")[0]);
                         totalLength.push(childWidth);
                         if (childWidth > parentNodeWidth * j) {
-                            testCount.push(childWidth);
+                            isCount.push(childWidth);
                         }
                     });
                 }
 
-                if (testCount.length === 0) {
-                    v.style.top = `${(testCount.length + 1) * 22}px`;
+                if (isCount.length === 0) {
+                    v.style.top = `${(isCount.length + 1) * 22}px`;
                 } else {
                     v.style.top = `${(totalLength.length + 1) * 32}px`;
                 }
+                heightArray.push(
+                    Number(v?.style?.top.split("px")[0]) + Number(getComputedStyle(v)?.height.split("px")[0])
+                );
             }
-            heightArray.push(Number(v?.style?.top.split("px")[0]));
         });
+
         const maxHeight = Math.max(...heightArray);
+
         Object.values(boxRef.current).forEach((v: any, i) => {
             if (v) {
-                v.parentNode.style.height = `${maxHeight + 40}px`;
+                v.parentNode.style.height = `${maxHeight + 30}px`;
             }
         });
     }, [createMonth, docsInfo, boxRef.current]);

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -29,7 +29,10 @@ const MyPage = () => {
                     <Avatar bg="teal.500" w="60px" h="60px" />
                     <Heading size="lg">{userInfo.email}</Heading>
                     <Badge mt="1" bg="blue.50" p="0.25rem 0.75rem">
-                        {userInfo.role === "admin" ? "관리자" : "직원"}
+                        {userInfo?.role === "admin" ? "관리자" : "직원"}
+                    </Badge>
+                    <Badge mt="1" bg="red.100" p="0.25rem 0.75rem">
+                        {userInfo?.company}
                     </Badge>
                 </Flex>
                 {userInfo.role === "worker" && (


### PR DESCRIPTION
- 캘린더 높이 계산 오류로 문서 겹치는 이슈 해결
  - 기존 계산은 top 값만 비교했지만 top + height 까지 비교해야 다음 컴포넌트가 겹치지 않음.